### PR TITLE
Make parser optionally less strict, support StringIO

### DIFF
--- a/lib/nrb/beerxml/parser.rb
+++ b/lib/nrb/beerxml/parser.rb
@@ -23,9 +23,10 @@ module NRB; module BeerXML
 
     include Inflector
 
-    attr_reader :builder, :reader
+    attr_reader :builder, :reader, :perform_validations
 
-    def initialize(builder: Builder.new, reader: Nokogiri::XML)
+    def initialize(builder: Builder.new, reader: Nokogiri::XML, perform_validations: true)
+      @perform_validations = perform_validations
       @builder = builder
       @reader = reader
     end
@@ -33,7 +34,7 @@ module NRB; module BeerXML
 
     def parse(entry)
       doc = case entry
-            when IO
+            when IO, StringIO
               parse_xml entry
             when String
               parse_path(file: entry)
@@ -114,7 +115,7 @@ module NRB; module BeerXML
 
         assign_child_to_parent parent, obj
 
-        validate obj
+        validate obj if perform_validations
 
         obj
       end


### PR DESCRIPTION
The strictness of the library is great if you are building beer software, but if you just want to load up a file can get in the way. Some applications out there don't generate complete BeerXML (i.e. BeerAlchemy didn't for one of my recipes) and that shouldn't get in the way of getting a usable object. This helps get rid of some of that pain by making validations an optional step in the parsing process.

It also adds support for `StringIO` because for some reason `StringIO.new.is_a?(IO)` returns false. It would be preferable to accept any kind of IO-like object such as file uploads, but this can act as a stand in for now.

Please let me know if there's something in this PR that you don't like and I'll gladly fix it up.
